### PR TITLE
should fix bug in pcr+ graph titles in vaxImpact

### DIFF
--- a/src/france/covid19_france_statut_vaccinal_drees.py
+++ b/src/france/covid19_france_statut_vaccinal_drees.py
@@ -831,7 +831,7 @@ fig.write_image(PATH + "images/charts/france/{}.jpeg".format(name_fig), scale=2,
 
 # In[14]:
 
-
+ages=df_drees_age_lastday.age.sort_values().unique()
 ages_str = ["0 à 19 ans", "20 à 39 ans", "40 à 59 ans", "60 à 79 ans", "plus 80 ans"]
 for idx, age in enumerate(ages):
     data_non_vaccines, data_completement_vaccines, data_completement_vaccines_rappel, data_partiellement_vaccines, _  = get_df_by_vaccine_status(df_drees_age[(df_drees_age.age==age)])


### PR DESCRIPTION
hello,

This should fix #1 

at line 400, there is a `ages = np.delete(ages, np.where(ages == '[0,19]'))`, which removed this age class, and then the pcr+ graph were computed on the `ages` list with missing first element.

let me know if i misunderstood something.